### PR TITLE
Enable paypal payment method

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -15,7 +15,7 @@ class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('ruudk_payment_mollie');
 
-        $methods = array('ideal', 'credit_card', 'mister_cash', 'paysafecard');
+        $methods = array('ideal', 'credit_card', 'mister_cash', 'paysafecard', 'paypal');
 
         $rootNode
             ->children()

--- a/Plugin/DefaultPlugin.php
+++ b/Plugin/DefaultPlugin.php
@@ -199,7 +199,8 @@ class DefaultPlugin extends AbstractPlugin
             'ideal'       => 'ideal',
             'mister_cash' => 'mistercash',
             'credit_card' => 'credit_card',
-            'paysafecard' => 'paysafecard'
+            'paysafecard' => 'paysafecard',
+            'paypal'      => 'paypal'
         );
 
         $name = substr($transaction->getPayment()->getPaymentInstruction()->getPaymentSystemName(), 7);

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ ruudk_payment_mollie:
       - mister_cash
       - credit_card
       - paysafecard
+      - paypal
 ```
 
 Make sure you set the `return_url` in the `predefined_data` for every payment method you enable:


### PR DESCRIPTION
Hi, 

Mollie just started with a paypal service, and as I want to use that, I enabled the support for support in the bundle with this commit.

However, it appears that Mollie does not have a working test environment for paypal. It generates a "Can't create Mollie payment" with a test API key. It does forward to paypal whenever using a live API key. 
