### PR TITLE
Throw ActionRequiredException if the response is a redirection

### DIFF
--- a/Plugin/DefaultPlugin.php
+++ b/Plugin/DefaultPlugin.php
@@ -121,6 +121,21 @@ class DefaultPlugin extends AbstractPlugin
                 throw $ex;
             }
 
+            if($response->isRedirect()) {
+                $ex = new ActionRequiredException('Redirect the user to Mollie.');
+                $ex->setFinancialTransaction($transaction);
+                $ex->setAction(new VisitUrl($response->getRedirectUrl()));
+
+                if($this->logger) {
+                    $this->logger->info(sprintf(
+                        'Create a new redirect exception for transaction "%s".',
+                        $response->getTransactionReference()
+                    ));
+                }
+
+                throw $ex;
+            }
+
             if($this->logger) {
                 $this->logger->info(sprintf(
                     'Waiting for notification from Mollie for transaction "%s".',


### PR DESCRIPTION
Hi Ruud!

I found that your code doesn't cover one specific case, when `$transaction` already has tracking id, but `$response` is a redirection to bank page. 

This little bug affects costumers that proceeded to payment page and then for example clicked "go back" button in their browser.