### PR TITLE
Preparing MollieType for Symfony 3

### DIFF
--- a/src/Form/MollieType.php
+++ b/src/Form/MollieType.php
@@ -22,7 +22,7 @@ class MollieType extends AbstractType
     /**
      * @return string
      */
-    public function getName()
+    public function getBlockPrefix()
     {
         return $this->name;
     }


### PR DESCRIPTION
In symfony 3, getBlockPrefix() is used and getName() should return fully qualified class name.