### PR TITLE
Add support for cardFingerprint

### DIFF
--- a/src/Plugin/DefaultPlugin.php
+++ b/src/Plugin/DefaultPlugin.php
@@ -46,7 +46,12 @@ class DefaultPlugin extends AbstractPlugin
 
     public function processes($name)
     {
-        return $name !== IdealType::class && preg_match('/Mollie/', $name);
+        return $name !== IdealType::class &&
+               $name !== 'mollie_ideal' &&
+               (
+                   preg_match('/Mollie/', $name) ||
+                   preg_match('/^mollie_/', $name)
+               );
     }
 
     public function approveAndDeposit(FinancialTransactionInterface $transaction, $retry)
@@ -78,6 +83,10 @@ class DefaultPlugin extends AbstractPlugin
 
                     if(!empty($data['details']['consumerAccount'])) {
                         $transaction->getExtendedData()->set('consumer_account_number', $data['details']['consumerAccount']);
+                    }
+
+                    if (!empty($data['details']['cardFingerprint'])) {
+                        $transaction->getExtendedData()->set('card_fingerprint', $data['details']['cardFingerprint']);
                     }
                 }
 

--- a/src/Plugin/IdealPlugin.php
+++ b/src/Plugin/IdealPlugin.php
@@ -11,7 +11,7 @@ class IdealPlugin extends DefaultPlugin
 {
     public function processes($name)
     {
-        return $name === IdealType::class;
+        return $name === IdealType::class || $name === 'mollie_ideal';
     }
 
     public function checkPaymentInstruction(PaymentInstructionInterface $instruction)


### PR DESCRIPTION
# What has been done
- [X] Backwards compatibility with Symfony 2
- [X] `cardFingerprint` property is saved to the extended data (if available)