### PR TITLE
Set choices as values in iDeal form

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     "require": {
         "php": "^7.0",
         "symfony/framework-bundle": "~2.8 || ~3.0",
+        "symfony/form": "~2.8 || ~3.0",
         "jms/payment-core-bundle": "~1.0",
         "psr/log": "~1.0",
         "omnipay/mollie": "~3.0"

--- a/src/Form/IdealType.php
+++ b/src/Form/IdealType.php
@@ -16,7 +16,6 @@ class IdealType extends AbstractType
     protected $issuers = array();
 
     /**
-     * @param string $name
      * @param array  $issuers
      */
     public function __construct(array $issuers)
@@ -31,15 +30,15 @@ class IdealType extends AbstractType
         $banks = array();
         $defaultBank = null;
         foreach($this->issuers AS $issuer) {
-            if('ideal' !== $issuer->getPaymentMethod()) {
+            if ('ideal' !== $issuer->getPaymentMethod()) {
                 continue;
             }
 
-            $banks[$issuer->getId()] = $issuer->getName();
+            $banks[$issuer->getName()] = $issuer->getId();
             $defaultBank = $issuer->getId();
         }
 
-        if(1 !== count($banks)) {
+        if (1 !== count($banks)) {
             $defaultBank = null;
         }
 
@@ -48,10 +47,11 @@ class IdealType extends AbstractType
         }
 
         $builder->add('bank', ChoiceType::class, array(
-            'label'       => 'ruudk_payment_mollie.ideal.bank.label',
-            'data'        => $defaultBank,
-            'empty_value' => 'ruudk_payment_mollie.ideal.bank.empty_value',
-            'choices'     => $banks
+            'label'             => 'ruudk_payment_mollie.ideal.bank.label',
+            'data'              => $defaultBank,
+            'empty_value'       => 'ruudk_payment_mollie.ideal.bank.empty_value',
+            'choices'           => $banks,
+            'choices_as_values' => true,
         ));
     }
 


### PR DESCRIPTION
This fixes more deprecations as the bank choices were still displayed in value => label style.