### PR TITLE
Add missing methods and iDEAL issuers

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ ruudk_payment_mollie:
       - banktransfer
       - belfius
       - kbc
+      - inghomepay
+      - bitcoin
+      - paypal
+      - paysafecard
       - ...
 ```
 See the [Mollie API documentation](https://www.mollie.nl/files/documentatie/payments-api.html) for all available methods.

--- a/src/DependencyInjection/RuudkPaymentMollieExtension.php
+++ b/src/DependencyInjection/RuudkPaymentMollieExtension.php
@@ -48,10 +48,7 @@ class RuudkPaymentMollieExtension extends Extension
         $definition->addArgument($mollieMethod);
 
         if($method === 'ideal') {
-            $definition->addArgument(sprintf(
-                '%%ruudk_payment_mollie.ideal.issuers.%s%%',
-                substr($config['api_key'], 0, 4) == 'live' ? 'live' : 'test'
-            ));
+            $definition->addArgument('ruudk_payment_mollie.ideal.issuers');
         }
 
         $definition->addTag('payment.method_form_type');

--- a/src/Form/BitcoinType.php
+++ b/src/Form/BitcoinType.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Ruudk\Payment\MollieBundle\Form;
+
+class BitcoinType extends NamedType
+{
+}

--- a/src/Form/InghomepayType.php
+++ b/src/Form/InghomepayType.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Ruudk\Payment\MollieBundle\Form;
+
+class InghomepayType extends NamedType
+{
+}

--- a/src/Form/PaypalType.php
+++ b/src/Form/PaypalType.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Ruudk\Payment\MollieBundle\Form;
+
+class PaypalType extends NamedType
+{
+}

--- a/src/Form/PaysafecardType.php
+++ b/src/Form/PaysafecardType.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Ruudk\Payment\MollieBundle\Form;
+
+class PaysafecardType extends NamedType
+{
+}

--- a/src/Plugin/DefaultPlugin.php
+++ b/src/Plugin/DefaultPlugin.php
@@ -14,10 +14,14 @@ use Psr\Log\LoggerInterface;
 use Omnipay\Mollie\Gateway;
 use Ruudk\Payment\MollieBundle\Exception\IdealIssuerTemporarilyUnavailableException;
 use Ruudk\Payment\MollieBundle\Exception\MollieTemporarilyUnavailableException;
+use Ruudk\Payment\MollieBundle\Form\BitcoinType;
 use Ruudk\Payment\MollieBundle\Form\CreditcardType;
 use Ruudk\Payment\MollieBundle\Form\IdealType;
+use Ruudk\Payment\MollieBundle\Form\InghomepayType;
 use Ruudk\Payment\MollieBundle\Form\KbcType;
 use Ruudk\Payment\MollieBundle\Form\MistercashType;
+use Ruudk\Payment\MollieBundle\Form\PaypalType;
+use Ruudk\Payment\MollieBundle\Form\PaysafecardType;
 use Ruudk\Payment\MollieBundle\Form\SofortType;
 use Ruudk\Payment\MollieBundle\Form\BanktransferType;
 use Ruudk\Payment\MollieBundle\Form\BelfiusType;
@@ -270,6 +274,14 @@ class DefaultPlugin extends AbstractPlugin
                 return 'belfius';
             case KbcType::class:
                 return 'kbc';
+            case InghomepayType::class:
+                return 'inghomepay';
+            case BitcoinType::class:
+                return 'bitcoin';
+            case PaypalType::class:
+                return 'paypal';
+            case PaysafecardType::class:
+                return 'paysafecard';
         }
 
         return substr($transaction->getPayment()->getPaymentInstruction()->getPaymentSystemName(), 7);

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -14,27 +14,20 @@
         <parameter key="ruudk_payment_mollie.form.banktransfer_type.class">Ruudk\Payment\MollieBundle\Form\BanktransferType</parameter>
         <parameter key="ruudk_payment_mollie.form.belfius_type.class">Ruudk\Payment\MollieBundle\Form\BelfiusType</parameter>
         <parameter key="ruudk_payment_mollie.form.kbc_type.class">Ruudk\Payment\MollieBundle\Form\KbcType</parameter>
+        <parameter key="ruudk_payment_mollie.form.inghomepay_type.class">Ruudk\Payment\MollieBundle\Form\InghomepayType</parameter>
+        <parameter key="ruudk_payment_mollie.form.bitcoin_type.class">Ruudk\Payment\MollieBundle\Form\BitcoinType</parameter>
+        <parameter key="ruudk_payment_mollie.form.paypal_type.class">Ruudk\Payment\MollieBundle\Form\PaypalType</parameter>
+        <parameter key="ruudk_payment_mollie.form.paysafecard_type.class">Ruudk\Payment\MollieBundle\Form\PaysafecardType</parameter>
         <parameter key="ruudk_payment_mollie.plugin.default.class">Ruudk\Payment\MollieBundle\Plugin\DefaultPlugin</parameter>
         <parameter key="ruudk_payment_mollie.plugin.ideal.class">Ruudk\Payment\MollieBundle\Plugin\IdealPlugin</parameter>
         <parameter key="ruudk_payment_mollie.api_key" />
-        <parameter type="collection" key="ruudk_payment_mollie.ideal.issuers.test">
-            <parameter key="ideal_ABNANL2A">ABN AMRO (test)</parameter>
-            <parameter key="ideal_ASNBNL21">ASN Bank (test)</parameter>
-            <parameter key="ideal_BUNQNL2A">Bunq (test)</parameter>
-            <parameter key="ideal_INGBNL2A">ING (test)</parameter>
-            <parameter key="ideal_KNABNL2H">Knab (test)</parameter>
-            <parameter key="ideal_RABONL2U">Rabobank (test)</parameter>
-            <parameter key="ideal_RBRBNL21">RegioBank (test)</parameter>
-            <parameter key="ideal_SNSBNL2A">SNS Bank (test)</parameter>
-            <parameter key="ideal_TRIONL2U">Triodos Bank (test)</parameter>
-            <parameter key="ideal_FVLBNL22">Van Lanschot (test)</parameter>
-        </parameter>
-        <parameter type="collection" key="ruudk_payment_mollie.ideal.issuers.live">
+        <parameter type="collection" key="ruudk_payment_mollie.ideal.issuers">
             <parameter key="ideal_ABNANL2A">ABN AMRO</parameter>
             <parameter key="ideal_ASNBNL21">ASN Bank</parameter>
-            <parameter key="ideal_BUNQNL2A">Bunq</parameter>
+            <parameter key="ideal_BUNQNL2A">bunq</parameter>
             <parameter key="ideal_INGBNL2A">ING</parameter>
             <parameter key="ideal_KNABNL2H">Knab</parameter>
+            <parameter key="ideal_MOYONL21">Moneyou</parameter>
             <parameter key="ideal_RABONL2U">Rabobank</parameter>
             <parameter key="ideal_RBRBNL21">RegioBank</parameter>
             <parameter key="ideal_SNSBNL2A">SNS Bank</parameter>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -24,7 +24,7 @@
         <parameter type="collection" key="ruudk_payment_mollie.ideal.issuers">
             <parameter key="ideal_ABNANL2A">ABN AMRO</parameter>
             <parameter key="ideal_ASNBNL21">ASN Bank</parameter>
-            <parameter key="ideal_BUNQNL2A">bunq</parameter>
+            <parameter key="ideal_BUNQNL2A">Bunq</parameter>
             <parameter key="ideal_INGBNL2A">ING</parameter>
             <parameter key="ideal_KNABNL2H">Knab</parameter>
             <parameter key="ideal_MOYONL21">Moneyou</parameter>


### PR DESCRIPTION
Added some missing methods:
- ING Home'pay (https://www.mollie.com/en/payments/ing-homepay)
- Paypal (https://www.mollie.com/en/payments/paypal)
- Paysafecard (https://www.mollie.com/en/payments/paysafecard)
- Bitcoin (https://www.mollie.com/en/payments/bitcoin)

Also corrected ``Bunq`` to ``bunq``.
Added ``Moneyou`` iDEAL issuer.
And squashes the test and live issuer lists together, since they are the same.