### PR TITLE
Use omnipay/mollie 4.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "symfony/form": "~3.4",
         "jms/payment-core-bundle": "~1.0",
         "psr/log": "~1.0",
-        "omnipay/mollie": "~3.0"
+        "omnipay/mollie": "~4.0"
     },
     "autoload": {
         "psr-4": { "Ruudk\\Payment\\MollieBundle\\": "src" }


### PR DESCRIPTION
omnipay/common 2.2 (required by omnipay/mollie 3.x) can't be installed with symfony 3.4, because it requires a guzzle/guzzle version which requires symfony/event-dispatcher which is now included in symfony/symfony