### PR TITLE
Handles payment failed case

### DIFF
--- a/src/Plugin/DefaultPlugin.php
+++ b/src/Plugin/DefaultPlugin.php
@@ -107,6 +107,24 @@ class DefaultPlugin extends AbstractPlugin
                 return;
             }
 
+
+            if('failed' === $response->getStatus()) {
+                $ex = new FinancialException('Payment failed.');
+                $ex->setFinancialTransaction($transaction);
+                $transaction->setResponseCode('FAILED');
+                $transaction->setReasonCode('FAILED');
+                $transaction->setState(FinancialTransactionInterface::STATE_FAILED);
+
+                if($this->logger) {
+                    $this->logger->info(sprintf(
+                        'Payment failed for transaction "%s".',
+                        $response->getTransactionReference()
+                    ));
+                }
+
+                throw $ex;
+            }
+            
             if($response->isCancelled()) {
                 $ex = new FinancialException('Payment cancelled.');
                 $ex->setFinancialTransaction($transaction);


### PR DESCRIPTION
When testing with Mollie I noticed that "failing" the payment didn't transition the financial exception away from the "pending" state. 

Handling the failed payments, means we can present the user with an error message and ask to try it again instead of showing a spinner.