### PR TITLE
Fix deprecations

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -30,7 +30,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->arrayNode('methods')
                     ->isRequired()
-                    ->cannotBeEmpty()
+                    ->requiresAtLeastOneElement()
                     ->prototype('scalar')
                     ->end()
                 ->end()

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -47,7 +47,7 @@
 
         <service id="ruudk_payment_mollie.gateway" class="%ruudk_payment_mollie.gateway.class%">
             <argument>null</argument>
-            <argument type="service" id="request" on-invalid="null" strict="false" />
+            <argument type="service" id="request" on-invalid="null" />
             <call method="setApiKey">
                 <argument>%ruudk_payment_mollie.api_key%</argument>
             </call>


### PR DESCRIPTION
Using Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition::cannotBeEmpty() at path "ruudk_payment_mollie.methods" has no effect, consider requiresAtLeastOneElement() instead. In 4.0 both methods will behave the same.

The "strict" attribute used when referencing the "request" service is deprecated since Symfony 3.3 and will be removed in 4.0.